### PR TITLE
docs: Update github documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Udacity's course _Writing READMEs_ explains the importance of documenting your w
 ## Resources
 
 * [Choose A License](http://choosealicense.com/) - Helpful website for picking out a license for your project.
-* [Github flavored markdown reference](https://help.github.com/categories/writing-on-github/) - Github's own documentation about documentation.
+* [Github flavored markdown reference](https://docs.github.com/en/get-started/writing-on-github) - Github's own documentation about documentation.
 
 ## Sample READMEs
 


### PR DESCRIPTION
Updated _Github flavored markdown reference_ in the **README.md** file, the current link is borken, not working and removed without redirection to the new one.
So i changed it with a new working link for the same destination which is for _Getting started with writing and formatting on GitHub_.